### PR TITLE
修正在 Firefox 底下無法點選元素的問題

### DIFF
--- a/src/pug/irc/index.pug
+++ b/src/pug/irc/index.pug
@@ -3,6 +3,6 @@ block vars
   - var title = "g0v 聊天室 / 零時政府揪松網"
 block head
 block body
-  div.abs(style="top:0;bottom:0;left:0;right:0;background:#f00;margin-top:73px;z-index:-1")
+  div.abs(style="top:0;bottom:0;left:0;right:0;background:#f00;margin-top:73px;z-index:1")
     iframe(src="https://kiwiirc.com/client/irc.freenode.net/#g0v.tw",style="width:100%;height:100%")
   div(style="width:100%;height:100%;margin-bottom:-73px;")


### PR DESCRIPTION
現行的 IRC 頁面，在 WebKit-based 瀏覽器底下或許可以正常運作，但在 Firefox 90 上會完全無法點到元素。

觀察原本的寫法 `z-index: -1`，感覺是為了要讓元素浮到最上面，但照 CSS 2.1 的標準來說，負值反而會把元素塞到最後面去（參照[這篇][1] StackOverflow）。

我先把它改成 `z-index: 1`，但如果 Chrome 測一下沒問題，好像也是可以整個拿掉？畢竟 `.abs` 已經會套用 `position: absolute` 屬性了，本來就會建立一個新的堆疊內容 (stacking context)，似乎不會產生早期那種圖層互卡的問題。

還請 @zbryikt @ronnywang 幫忙 review 了。

[1]: https://stackoverflow.com/questions/34924571/why-negative-z-index-hides-element-in-firefox-but-not-in-chrome-safari